### PR TITLE
env: alias nvim -d with vimdiff

### DIFF
--- a/conf/base/etc/environment.d/50-progs.conf
+++ b/conf/base/etc/environment.d/50-progs.conf
@@ -1,4 +1,4 @@
 EDITOR=nvim
 VISUAL=nvim
 BAT_THEME=gruvbox-dark
-DIFFPROG="nvim -d"
+DIFFPROG="vimdiff"

--- a/conf/base/usr/local/bin/vimdiff
+++ b/conf/base/usr/local/bin/vimdiff
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+nvim -d

--- a/pkg/PKGBUILD
+++ b/pkg/PKGBUILD
@@ -1,7 +1,7 @@
 pkgbase='couldinho'
 pkgname=(couldinho-base couldinho-desktop couldinho-laptop couldinho-dev couldinho-sec couldinho-vmware)
 pkgver=3
-pkgrel=46
+pkgrel=47
 pkgdesc="Packages for couldinho systems"
 arch=(x86_64)
 url="https://github.com/kontax/arch-packages"


### PR DESCRIPTION
When exporting the environment, spaces within the "nvim -d" variable
cause issues. I've just created a simple script called vimdiff that
points to nvim -d and used that as the variable instead.