### PR TITLE
Update dependencies and `pkgrel` for `couldinho-dev`

### DIFF
--- a/pkg/PKGBUILD
+++ b/pkg/PKGBUILD
@@ -1,7 +1,7 @@
 pkgbase='couldinho'
 pkgname=(couldinho-base couldinho-desktop couldinho-laptop couldinho-dev couldinho-sec couldinho-vmware couldinho-media-server couldinho-media-client)
 pkgver=3
-pkgrel=78
+pkgrel=79
 pkgdesc="Packages for couldinho systems"
 arch=(x86_64)
 url="https://github.com/kontax/arch-packages"
@@ -474,7 +474,7 @@ package_couldinho-dev() {
 
     # Cloud
     depends+=(
-        aws-cli                 # Command line interface to AWS
+        aws-cli-v2              # Command line interface to AWS
         aws-sam-cli             # Client for AWS SAM serverless
         npm                     # Node package manager (used for serverless)
     )


### PR DESCRIPTION
- Change `aws-cli` to `aws-cli-v2` in `couldinho-dev` dependencies